### PR TITLE
improvements around reschedule logic

### DIFF
--- a/components/booking/pages/BookingPage.tsx
+++ b/components/booking/pages/BookingPage.tsx
@@ -36,7 +36,7 @@ import { TeamBookingPageProps } from "../../../pages/team/[slug]/book";
 
 type BookingPageProps = BookPageProps | TeamBookingPageProps;
 
-const BookingPage = (props: BookingPageProps) => {
+function BookingPage(props: BookingPageProps) {
   const { t } = useLocale({ localeProp: props.localeProp });
   const router = useRouter();
   const { rescheduleUid } = router.query;
@@ -59,7 +59,7 @@ const BookingPage = (props: BookingPageProps) => {
 
   useEffect(() => {
     telemetry.withJitsu((jitsu) => jitsu.track(telemetryEventTypes.timeSelected, collectPageParameters()));
-  }, []);
+  }, [telemetry]);
 
   function toggleGuestEmailInput() {
     setGuestToggle(!guestToggle);
@@ -149,6 +149,7 @@ const BookingPage = (props: BookingPageProps) => {
       });
 
       if (content?.id) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const params: { [k: string]: any } = {
           date,
           type: props.eventType.id,
@@ -193,6 +194,7 @@ const BookingPage = (props: BookingPageProps) => {
     book();
   };
 
+  // es-lint-disable-next-line react-hooks/exhaustive-deps
   const bookingHandler = useCallback(_bookingHandler, []);
 
   return (
@@ -459,7 +461,7 @@ const BookingPage = (props: BookingPageProps) => {
                       {t("additional_notes")}
                     </label>
                     <textarea
-                      required={props.eventType.slug === "async"}
+                      required
                       name="notes"
                       id="notes"
                       rows={3}
@@ -499,6 +501,6 @@ const BookingPage = (props: BookingPageProps) => {
       </main>
     </div>
   );
-};
+}
 
 export default BookingPage;

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -18,7 +18,7 @@ class MyDocument extends Document<Props> {
           <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
           <link rel="manifest" href="/site.webmanifest" />
           <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#000000" />
-          <meta name="msapplication-TileColor" content="#ff0000" />
+          <meta name="msapplication-TileColor" content="#F3C93C" />
           <meta name="theme-color" content="#F3C93C" media="(prefers-color-scheme: light)" />
           <meta name="theme-color" content="#141414" media="(prefers-color-scheme: dark)" />
           <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/pages/cancel/[uid].tsx
+++ b/pages/cancel/[uid].tsx
@@ -22,7 +22,7 @@ export default function Type(props: InferGetServerSidePropsType<typeof getServer
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [is24h, setIs24h] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(props.booking ? null : "This meeting was already cancelled");
+  const [error, setError] = useState(props.booking ? null : "Meeting not found.");
   const telemetry = useTelemetry();
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/pages/cancel/[uid].tsx
+++ b/pages/cancel/[uid].tsx
@@ -124,17 +124,24 @@ export default function Type(props: InferGetServerSidePropsType<typeof getServer
                         </div>
                       </div>
                     </div>
-                    {props.cancellationAllowed && (
+                    <div className="flex space-x-2 justify-center">
+                      {props.cancellationAllowed && (
+                        <div className="mt-5 space-x-2 text-center sm:mt-6">
+                          <Button
+                            color="secondary"
+                            data-testid="cancel"
+                            onClick={cancellationHandler}
+                            loading={loading}>
+                            Cancel
+                          </Button>
+                        </div>
+                      )}
                       <div className="mt-5 space-x-2 text-center sm:mt-6">
-                        <Button
-                          color="secondary"
-                          data-testid="cancel"
-                          onClick={cancellationHandler}
-                          loading={loading}>
-                          Cancel
+                        <Button color="secondary" onClick={() => router.back()}>
+                          Go Back
                         </Button>
                       </div>
-                    )}
+                    </div>
                   </>
                 )}
               </div>

--- a/pages/success.tsx
+++ b/pages/success.tsx
@@ -96,7 +96,11 @@ export default function Success(props: InferGetServerSidePropsType<typeof getSer
                     </div>
                     <div className="mt-3 text-center sm:mt-5">
                       <h3 className="text-2xl font-semibold leading-6 text-neutral-900" id="modal-headline">
-                        {needsConfirmation ? "Submitted" : "This meeting is scheduled"}
+                        {needsConfirmation
+                          ? "Submitted"
+                          : reschedule == "true"
+                          ? "Reschedule successful"
+                          : "This meeting is scheduled"}
                       </h3>
                       <div className="mt-3">
                         <p className="text-sm text-neutral-600 ">


### PR DESCRIPTION
> make it so that the uid will no longer be updated (the better tradeoff) and that the cancel page with a non-existent uid reads “Could not found meeting” since meetings are no longer deleted when they're cancelled