### PR TITLE
fix handling of uids and reschedule

### DIFF
--- a/pages/api/book/event.ts
+++ b/pages/api/book/event.ts
@@ -649,7 +649,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   );
   await Promise.all(promises);
 
-  if (referencesToCreate && referencesToCreate.length) {
+  if (!rescheduleUid && referencesToCreate && referencesToCreate.length) {
     await prisma.booking.update({
       where: {
         uid: booking.uid,


### PR DESCRIPTION
This PR ensures that when meetings are rescheduled meeting their uids are persisted via not creating new references for them as was previously required